### PR TITLE
Python Worker Server-Side Middleware

### DIFF
--- a/examples/producer_middleware.py
+++ b/examples/producer_middleware.py
@@ -1,9 +1,0 @@
-import faktory
-import time
-
-with faktory.connection() as client:
-    while True:
-        client.queue('test', args=(1, 2), queue='default')
-        time.sleep(1)
-        client.queue('test_1', args=(1, 2), queue='default')
-        time.sleep(1)

--- a/examples/producer_middleware.py
+++ b/examples/producer_middleware.py
@@ -4,7 +4,7 @@ import time
 logging.basicConfig(level=logging.INFO)
 
 
-with faktory.connection(faktory="tcp://localhost:7419") as client:
+with faktory.connection() as client:
     while True:
         client.queue('test', args=(1,2), queue='default')
         time.sleep(5)

--- a/examples/producer_middleware.py
+++ b/examples/producer_middleware.py
@@ -1,10 +1,9 @@
-import logging
 import faktory
 import time
-logging.basicConfig(level=logging.INFO)
-
 
 with faktory.connection() as client:
     while True:
-        client.queue('test', args=(1,2), queue='default')
-        time.sleep(5)
+        client.queue('test', args=(1, 2), queue='default')
+        time.sleep(1)
+        client.queue('test_1', args=(1, 2), queue='default')
+        time.sleep(1)

--- a/examples/producer_middleware.py
+++ b/examples/producer_middleware.py
@@ -1,0 +1,10 @@
+import logging
+import faktory
+import time
+logging.basicConfig(level=logging.INFO)
+
+
+with faktory.connection(faktory="tcp://localhost:7419") as client:
+    while True:
+        client.queue('test', args=(1,2), queue='default')
+        time.sleep(5)

--- a/examples/worker_middleware.py
+++ b/examples/worker_middleware.py
@@ -5,12 +5,16 @@ logging.basicConfig(level=logging.INFO)
 
 def test_function(x,y):
     return x+y
-
+#all client middleware functions muss pass the jid, func, and args, as the first 3 parameters
 def simple_middleware_function(jid, func, args):
     logging.info(jid)
     logging.info(func)
     logging.info(args)
 
+#change the values of function arguments
+#changed values must be returned as a dict with either jid, func, or args as a key
+#args must be converted to a tuple before hashing
+#jid and func must remain strings
 def change_args(jid, func, args):
     if func == 'test':
         args[0] = 4
@@ -18,10 +22,12 @@ def change_args(jid, func, args):
         middleware_return = {'args': args}
         return middleware_return
 
+#jobs can be killed by returning "kill" to the worker
 def kill_jobs(jid, func, args):
     if func == 'test_1':
         return 'kill'
 
+#a variable number of arguments may be passed to middleware and used within the middleware functions
 def pass_extra_param(jid, func, args, extra_param):
     if func == 'test':
         args[1] = extra_param
@@ -29,6 +35,9 @@ def pass_extra_param(jid, func, args, extra_param):
         middleware_return = {'args': args}
         return middleware_return
 
+#server middlware functions must take the jid, job_status, and exception as the first 3 parameters
+#jobs killed by middleware and jobs who've successfully executed don't pass exceptions
+#similar to client middleware, server middleware can take a variable number of parameters
 def server_middleware(jid, job_status, exception):
     if job_status is True:
         logging.info('job id: {} finished successfully'.format(jid))
@@ -42,7 +51,11 @@ w = faktory.Worker(faktory="tcp://localhost:7419",  queues=['default'], concurre
 
 w.register('test', test_function)
 w.register('test_1', test_function)
+
+#middlware executes in the order it's registered
 w.server_middleware_reg(server_middleware)
+#server middleware is called after job processing
+#client middleware is called before a job is submitted
 w.client_middleware_reg(simple_middleware_function)
 w.client_middleware_reg(change_args)
 w.client_middleware_reg(kill_jobs)

--- a/examples/worker_middleware.py
+++ b/examples/worker_middleware.py
@@ -23,9 +23,11 @@ def change_args(jid, func, args):
         return middleware_return
 
 #jobs can be killed by returning "kill" to the worker
+#do not return kill : false as this is the defualt behavior and would behave unexpectedly
 def kill_jobs(jid, func, args):
     if func == 'test_1':
-        return 'kill'
+        middleware_return = {'kill': True}
+        return middleware_return
 
 #a variable number of arguments may be passed to middleware and used within the middleware functions
 def pass_extra_param(jid, func, args, extra_param):
@@ -35,10 +37,10 @@ def pass_extra_param(jid, func, args, extra_param):
         middleware_return = {'args': args}
         return middleware_return
 
-#server middlware functions must take the jid, job_status, and exception as the first 3 parameters
+#server middlware functions must take the jid, job_success, and exception as the first 3 parameters
 #jobs killed by middleware and jobs who've successfully executed don't pass exceptions
 #similar to client middleware, server middleware can take a variable number of parameters
-def server_middleware(jid, job_status, exception):
+def server_middleware(jid, job_success, exception):
     if job_status is True:
         logging.info('job id: {} finished successfully'.format(jid))
     else:

--- a/examples/worker_middleware.py
+++ b/examples/worker_middleware.py
@@ -22,8 +22,8 @@ def change_args(jid, func, args):
         middleware_return = {'args': args}
         return middleware_return
 
-#jobs can be killed by returning "kill" to the worker
-#do not return kill : false as this is the defualt behavior and would behave unexpectedly
+#jobs can be killed by returning "kill":true to the worker
+#it is unecessary to return "kill":false as this is the default behavior
 def kill_jobs(jid, func, args):
     if func == 'test_1':
         middleware_return = {'kill': True}

--- a/examples/worker_middleware.py
+++ b/examples/worker_middleware.py
@@ -7,10 +7,10 @@ def test_function(x,y):
     return x+y
 
 
-def middleware_function(a, b, c):
-    logging.info(a)
-    logging.info(b)
-    logging.info(c)
+def middleware_function(jobId, jobType, jobArgs):
+    logging.info(jobId)
+    logging.info(jobType)
+    logging.info(jobArgs)
 
 w = faktory.Worker(faktory="tcp://localhost:7419",  queues=['default'], concurrency=1)
 

--- a/examples/worker_middleware.py
+++ b/examples/worker_middleware.py
@@ -6,15 +6,46 @@ logging.basicConfig(level=logging.INFO)
 def test_function(x,y):
     return x+y
 
+def simple_middleware_function(jid, func, args):
+    logging.info(jid)
+    logging.info(func)
+    logging.info(args)
 
-def middleware_function(jobId, jobType, jobArgs):
-    logging.info(jobId)
-    logging.info(jobType)
-    logging.info(jobArgs)
+def change_args(jid, func, args):
+    if func == 'test':
+        args[0] = 4
+        args = tuple(args)
+        middleware_return = {'args': args}
+        return middleware_return
+
+def kill_jobs(jid, func, args):
+    if func == 'test_1':
+        return 'kill'
+
+def pass_extra_param(jid, func, args, extra_param):
+    if func == 'test':
+        args[1] = extra_param
+        args = tuple(args)
+        middleware_return = {'args': args}
+        return middleware_return
+
+def server_middleware(jid, job_status, exception):
+    if job_status is True:
+        logging.info('job id: {} finished successfully'.format(jid))
+    else:
+        logging.info('job id: {} failed'.format(jid))
+        if exception is not None:
+            logging.info('exception: {}\nmessage: {}'.format(type(exception), str(exception)))
+
 
 w = faktory.Worker(faktory="tcp://localhost:7419",  queues=['default'], concurrency=1)
 
 w.register('test', test_function)
-w.middleware_reg(middleware_function)
+w.register('test_1', test_function)
+w.server_middleware_reg(server_middleware)
+w.client_middleware_reg(simple_middleware_function)
+w.client_middleware_reg(change_args)
+w.client_middleware_reg(kill_jobs)
+w.client_middleware_reg(pass_extra_param, 20)
 #runs worker until ctrl-c or shutdown from faktory
 w.run()

--- a/examples/worker_middleware.py
+++ b/examples/worker_middleware.py
@@ -1,0 +1,20 @@
+import logging
+import faktory
+import time
+logging.basicConfig(level=logging.INFO)
+
+def test_function(x,y):
+    return x+y
+
+
+def middleware_function(a, b, c):
+    logging.info(a)
+    logging.info(b)
+    logging.info(c)
+
+w = faktory.Worker(faktory="tcp://localhost:7419",  queues=['default'], concurrency=1)
+
+w.register('test', test_function)
+w.middleware_reg(middleware_function)
+#runs worker until ctrl-c or shutdown from faktory
+w.run()

--- a/examples/worker_middleware.py
+++ b/examples/worker_middleware.py
@@ -16,14 +16,14 @@ def simple_middleware_function(job_info):
     logging.info(func)
     logging.info(args)
 
-def change_args(job_info: list):
+def change_args(job_info):
     args = job_info[2]
     args[0] = 4
     job_info[2] = args
     return job_info
 
 def server_middleware(jid, job_success, exception):
-    if job_status is True:
+    if job_success is True:
         logging.info('job id: {} finished successfully'.format(jid))
     else:
         logging.info('job id: {} failed'.format(jid))

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -205,6 +205,13 @@ class Worker:
         except StopIteration:
             self.process(job)
 
+    def logging_middleware_reg(self, middleware_function):
+        self._logging_middleware.append(middleware_function)
+
+    def _call_logging_middleware(self, jid, job_success, exception = None):
+        for middleware_function in self._logging_middleware:
+            middleware_function(jid, job_success, exception)
+
     def tick(self):
         if self._pending:
             self.send_status_to_faktory()
@@ -275,6 +282,8 @@ class Worker:
     def _ack(self, jid: str):
         self.faktory.reply("ACK", {'jid': jid})
         ok = next(self.faktory.get_message())
+        if self._logging_middleware:
+            self._call_logging_middleware(jid, True, None)
 
     def _fail(self, jid: str, exception=None):
         response = {
@@ -286,6 +295,8 @@ class Worker:
 
         self.faktory.reply("FAIL", response)
         ok = next(self.faktory.get_message())
+        if self._logging_middleware:
+            self._call_logging_middleware(jid, False, exception)
 
     def fail_all_jobs(self):
         for future in self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -65,7 +65,7 @@ class Worker:
         self._last_heartbeat = None
         self._tasks = dict()
         self._pending = list()
-        self._middleware = dict()
+        self._middleware = list()
         self._disconnect_after = None
         self._executor = None
 
@@ -195,23 +195,20 @@ class Worker:
 
         #iterate through all middleware functions
         #call middleware functions for each key/pair value
-        for middleware_function, args in self._middleware.items():
-            if args:
-                middleware_function(args)
-            else:
-                middleware_function()
+        for middleware_function in self._middleware:
+            middleware_function(jobId, jobType, jobArgs)
 
-    def middleware(self, middleware_function, *args):
+    def middleware(self, middleware_function):
         #if the function is already registered within the middleware
         #then ignore it to rewrite the assignment
 
         #remove this line to overwrite functions
         if middleware_function not in self._middleware:
-            self._middleware[middleware_function] = args
+            self._middleware.append(middleware_function)
 
     def remove_middleware(self, middleware_function):
         if middleware_function in self._middleware:
-            del self._middleware[middleware_function]
+            self._middleware.remove(middleware_function)
 
     def tick(self):
         if self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -65,6 +65,7 @@ class Worker:
         self._pending = list()
         self._logging_middleware = list()
         self._server_middleware = list()
+        self._middleware_index = 0
         self._disconnect_after = None
         self._executor = None
         self._middlewareIterator = None
@@ -200,10 +201,12 @@ class Worker:
         middlewareChain(self, job)
 
     def chain_middleware(self, job):
-        try:#yield
-            middlewareChain = next(self._middlewareIterator)
-            middlewareChain(self, job)
-        except StopIteration:
+        if i < len(self._server_middleware):
+            foo = self._server_middleware[i]
+            i += 1
+            foo(self, job)
+        else:
+            self._middleware_index = 0
             self.process(job)
 
     def logging_middleware_reg(self, middleware_function):

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -64,8 +64,8 @@ class Worker:
         self._last_heartbeat = None
         self._tasks = dict()
         self._pending = list()
-        self._client_middleware = OrderedDict()
-        self._server_middleware = OrderedDict()
+        self._client_middleware = list()
+        self._server_middleware = list()
         self._middleware_values = list()
         self._disconnect_after = None
         self._executor = None
@@ -193,29 +193,27 @@ class Worker:
             self.faktory.disconnect()
 
     def _call_client_middleware(self, job_info):
-        for middleware_function, function_args in self._client_middleware.items():
-            middleware_return = middleware_function(job_info, *function_args)
+        for middleware_function in self._client_middleware.items():
+            middleware_return = middleware_function(job_info)
 
             if middleware_return:
                 if type(middleware_return) is list:
                     self._middleware_values[0] = middleware_return[0]
-                    self._middleware_values[1] = middleware_return[1]
-                    self._middleware_values[2] = middleware_return[2]
+                    self.middleware_value[1] = middleware_value[1]
+                    self.middleware_value[2] = middleware_value[2]
 
                 else:
                     self.log.debug("{} returned unexpected type".format(middleware_function.__name__))
-            else:
-                self.log.info("called middleware function with no return value")
 
-    def client_middleware_reg(self, middleware_function, *args):
-        self._client_middleware[middleware_function] = args
+    def client_middleware_reg(self, middleware_function):
+        self._client_middleware.append(middleware_return)
 
-    def server_middleware_reg(self, middleware_function, *args):
-        self._server_middleware[middleware_function] = args
+    def server_middleware_reg(self, middleware_function):
+        self._server_middleware.append(middleware_function)
 
     def _call_server_middleware(self, jid, job_success, exception = None):
-        for middleware_function, function_args in self._server_middleware.items():
-            middleware_function(jid, job_success, exception, *function_args)
+        for middleware_function in self._server_middleware.items():
+            middleware_function(jid, job_success, exception)
 
     def tick(self):
         if self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -198,7 +198,7 @@ class Worker:
         for middleware_function in self._middleware:
             middleware_function(jobId, jobType, jobArgs)
 
-    def middleware(self, middleware_function):
+    def middleware_reg(self, middleware_function):
         #if the function is already registered within the middleware
         #then ignore it to rewrite the assignment
 

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -247,7 +247,7 @@ class Worker:
                     if self._middleware_values:
 
                         if "kill" in middleware_return:
-                            if middleware_return["kill"] is True
+                            if middleware_return["kill"] is True:
                                 self._fail(jid)
                                 self.log.debug("force failed job {}".format(jid))
                                 self._cancel_job = False

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -212,7 +212,7 @@ class Worker:
                 if self._server_middleware:
                     self._call_server_middleware(job)
                 else:
-                    self._process(job)
+                    self.process(job)
         else:
             if self.is_disconnecting:
                 if self.can_disconnect:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -206,7 +206,7 @@ class Worker:
 
     def _call_server_middleware(self, jobId, status, exception = None):
         for middleware_function, function_args in self._server_middleware.items():
-            middleware_function(jobId, status, *function_args)
+            middleware_function(jobId, status, exception, *function_args)
 
     def tick(self):
         if self._pending:
@@ -274,7 +274,7 @@ class Worker:
     def _ack(self, jid: str):
         self.faktory.reply("ACK", {'jid': jid})
         ok = next(self.faktory.get_message())
-        self._call_server_middleware(jid, "finished")
+        self._call_server_middleware(jid, "finished", None)
 
     def _fail(self, jid: str, exception=None):
         response = {

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -65,7 +65,7 @@ class Worker:
         self._last_heartbeat = None
         self._tasks = dict()
         self._pending = list()
-        self._middleware = list()
+        self._middleware = dict()
         self._disconnect_after = None
         self._executor = None
 
@@ -194,17 +194,20 @@ class Worker:
     def _call_middleware(self, jobId, jobType, jobArgs):
 
         #iterate through all middleware functions
-        #call middleware functions for each key/pair value
-        for middleware_function in self._middleware:
-            middleware_function(jobId, jobType, jobArgs)
+        #call middleware functions for each item in the list
+        for middleware_function, function_args in self._middleware.items():
+            if function_args:
+                middleware_function(jobId, jobType, jobArgs, *function_args)
+            else:
+                middleware_function(jobId, jobType, jobArgs)
 
-    def middleware_reg(self, middleware_function):
+    def middleware_reg(self, middleware_function, *args):
         #if the function is already registered within the middleware
         #then ignore it to rewrite the assignment
 
         #remove this line to overwrite functions
         if middleware_function not in self._middleware:
-            self._middleware.append(middleware_function)
+            self._middleware[middleware_function] = args
 
     def remove_middleware(self, middleware_function):
         if middleware_function in self._middleware:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -204,7 +204,7 @@ class Worker:
         #"register" middleware by adding it and its args to a dict()
         self._server_middleware[middleware_function] = args
 
-    def _call_server_middleware(self, jobId, status):
+    def _call_server_middleware(self, jobId, status, exception = None):
         for middleware_function, function_args in self._server_middleware.items():
             middleware_function(jobId, status, *function_args)
 
@@ -286,7 +286,7 @@ class Worker:
 
         self.faktory.reply("FAIL", response)
         ok = next(self.faktory.get_message())
-        self._call_server_middleware(jid, "failed")
+        self._call_server_middleware(jid, "failed", exception)
 
     def fail_all_jobs(self):
         for future in self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -274,7 +274,7 @@ class Worker:
     def _ack(self, jid: str):
         self.faktory.reply("ACK", {'jid': jid})
         ok = next(self.faktory.get_message())
-        _call_server_middleware(jid, "finished")
+        self._call_server_middleware(jid, "finished")
 
     def _fail(self, jid: str, exception=None):
         response = {
@@ -286,7 +286,7 @@ class Worker:
 
         self.faktory.reply("FAIL", response)
         ok = next(self.faktory.get_message())
-        _call_server_middleware(jid, "failed")
+        self._call_server_middleware(jid, "failed")
 
     def fail_all_jobs(self):
         for future in self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -196,18 +196,12 @@ class Worker:
         #iterate through all middleware functions
         #call middleware functions for each item in the list
         for middleware_function, function_args in self._middleware.items():
-            if function_args:
-                middleware_function(jobId, jobType, jobArgs, *function_args)
-            else:
-                middleware_function(jobId, jobType, jobArgs)
+            middleware_function(jobId, jobType, jobArgs, *function_args)
 
     def middleware_reg(self, middleware_function, *args):
-        #if the function is already registered within the middleware
-        #then ignore it to rewrite the assignment
-
-        #remove this line to overwrite functions
-        if middleware_function not in self._middleware:
-            self._middleware[middleware_function] = args
+        #"register" middleware by adding it to a hash where
+        #the function name is the key and the args represent the value
+        self._middleware[middleware_function] = args
 
     def remove_middleware(self, middleware_function):
         if middleware_function in self._middleware:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -192,7 +192,6 @@ class Worker:
             self.faktory.disconnect()
 
     def _call_middleware(self, jobId, jobType, jobArgs):
-
         #iterate through all middleware functions
         #call middleware functions for each item in the list
         for middleware_function, function_args in self._middleware.items():
@@ -205,7 +204,7 @@ class Worker:
 
     def remove_middleware(self, middleware_function):
         if middleware_function in self._middleware:
-            self._middleware.remove(middleware_function)
+            del self._middleware[middleware_function]
 
     def tick(self):
         if self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -235,9 +235,10 @@ class Worker:
                 if self._client_middleware:
                     self._call_client_middleware(jid, func, args)
 
-                    if self._cancel_job == True:
+                    if self._cancel_job is True:
                         self._cancel_job = False
                         self._fail(jid)
+                        self.log.info("force failed job {}".format(jid))
                         return
 
                     if self._middleware_values:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -244,16 +244,14 @@ class Worker:
                 if self._client_middleware:
                     self._call_client_middleware(jid, func, args)
 
-                    if self._middleware_values:
+                    if self._cancel_job is True:
+                            self._fail(jid)
+                            self.log.debug("force failed job {}".format(jid))
+                            self._cancel_job = False
+                            self._middleware_values.clear()
+                            return
 
-                        if "kill" in middleware_return:
-                            if middleware_return["kill"] is True:
-                                self._fail(jid)
-                                self.log.debug("force failed job {}".format(jid))
-                                self._cancel_job = False
-                                self._middleware_values.clear()
-                                return
-
+                    elif self._middleware_values:
                         if "jid" in self._middleware_values:
                             jid = self._middleware_values["jid"]
                         if "func" in self._middleware_values:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -242,7 +242,7 @@ class Worker:
                     self._fail(future.job_id, exception=e)
                     self.log.exception("Task failed: {}".format(future.job_id))
 
-    def process(self, job_load):
+    def process(self, job):
         jid = str(job.get('jid'))
         func = str(job.get('jobtype'))
         args = job.get('args')

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -195,7 +195,7 @@ class Worker:
 
     def _call_server_middleware(self, job):
         self._middlewareIterator = iter(self._server_middleware)
-        middlewareChain = next(middlewareIterator)
+        middlewareChain = next(self._middlewareIterator)
         middlewareChain(self, job)
 
     def chain_middleware(self, job):

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -223,7 +223,7 @@ class Worker:
                 func = job.get('jobtype')
                 args = job.get('args')
 
-                if self._middleware:
+                if self._client_middleware:
                     self._call_client_middleware(jid, func, args)
 
                 self._process(jid, func, args)

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -201,9 +201,9 @@ class Worker:
         middlewareChain(self, job)
 
     def chain_middleware(self, job):
-        if i < len(self._server_middleware):
-            foo = self._server_middleware[i]
-            i += 1
+        if self._middleware_index < len(self._server_middleware):
+            foo = self._server_middleware[self._middleware_index]
+            self._middleware_index += 1
             foo(self, job)
         else:
             self._middleware_index = 0

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -249,7 +249,7 @@ class Worker:
         args = job.get('args')
 
         try:
-            task = self.get_registered_task(job)
+            task = self.get_registered_task(func)
             if task.bind:
                 # pass the jid as argument 1 if the task has bind=True
                 args = [jid, ] + args

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -211,6 +211,9 @@ class Worker:
                 elif middleware_return == "kill":
                     self._cancel_job = True
 
+                else:
+                    self.log.debug("{} returned unexpected type".format(middleware_function.__name__))
+
     def client_middleware_reg(self, middleware_function, *args):
         self._client_middleware[middleware_function] = args
 

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -193,7 +193,7 @@ class Worker:
             self.faktory.disconnect()
 
     def _call_client_middleware(self, job_info):
-        for middleware_function in self._client_middleware.items():
+        for middleware_function in self._client_middleware:
             middleware_return = middleware_function(job_info)
 
             if middleware_return:
@@ -212,7 +212,7 @@ class Worker:
         self._server_middleware.append(middleware_function)
 
     def _call_server_middleware(self, jid, job_success, exception = None):
-        for middleware_function in self._server_middleware.items():
+        for middleware_function in self._server_middleware:
             middleware_function(jid, job_success, exception)
 
     def tick(self):

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -209,6 +209,10 @@ class Worker:
         if middleware_function not in self._middleware:
             self._middleware[middleware_function] = args
 
+    def remove_middleware(self, middleware_function):
+        if middleware_function in self._middleware:
+            del self._middleware[middleware_function]
+
     def tick(self):
         if self._pending:
             self.send_status_to_faktory()

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -191,17 +191,13 @@ class Worker:
             self.faktory.disconnect()
 
     def _call_client_middleware(self, jobId, jobType, jobArgs):
-        #iterate through all middleware functions
-        #call each middleware function in the dict
         for middleware_function, function_args in self._client_middleware.items():
             middleware_function(jobId, jobType, jobArgs, *function_args)
 
     def client_middleware_reg(self, middleware_function, *args):
-        #"register" middleware by adding it and its args to a dict()
         self._client_middleware[middleware_function] = args
 
     def server_middleware_reg(self, middleware_function, *args):
-        #"register" middleware by adding it and its args to a dict()
         self._server_middleware[middleware_function] = args
 
     def _call_server_middleware(self, jobId, status, exception = None):
@@ -274,7 +270,8 @@ class Worker:
     def _ack(self, jid: str):
         self.faktory.reply("ACK", {'jid': jid})
         ok = next(self.faktory.get_message())
-        self._call_server_middleware(jid, "finished", None)
+        if self._server_middleware:
+            self._call_server_middleware(jid, "finished", None)
 
     def _fail(self, jid: str, exception=None):
         response = {
@@ -286,7 +283,8 @@ class Worker:
 
         self.faktory.reply("FAIL", response)
         ok = next(self.faktory.get_message())
-        self._call_server_middleware(jid, "failed", exception)
+        if self._server_middleware:
+            self._call_server_middleware(jid, "failed", exception)
 
     def fail_all_jobs(self):
         for future in self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -207,7 +207,7 @@ class Worker:
                         self._middleware_values["func"] = middleware_return["func"]
                     if "args" in middleware_return:
                         self._middleware_values["args"] = tuple(middleware_return["args"])
-                        self.log(self._middleware_values["args"])
+                        self.log.info(self._middleware_values["args"])
 
                 elif middleware_return == "kill":
                     self._cancel_job = True

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -206,7 +206,7 @@ class Worker:
                     self.log.debug("{} returned unexpected type".format(middleware_function.__name__))
 
     def client_middleware_reg(self, middleware_function):
-        self._client_middleware.append(middleware_return)
+        self._client_middleware.append(middleware_function)
 
     def server_middleware_reg(self, middleware_function):
         self._server_middleware.append(middleware_function)

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -206,7 +206,6 @@ class Worker:
                     if "func" in middleware_return:
                         self._middleware_values["func"] = middleware_return["func"]
                     if "args" in middleware_return:
-                        self.log.info(middleware_return[args])
                         self._middleware_values["args"] = middleware_return["args"]
 
                 elif middleware_return == "kill":
@@ -253,7 +252,6 @@ class Worker:
                             func = self._middleware_values["func"]
                         if "args" in self._middleware_values:
                             args = self._middleware_values["args"]
-                            self.log.info(args)
                         self._middleware_values.clear()
 
                 self._process(jid, func, args)

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -68,7 +68,6 @@ class Worker:
         self._middleware_index = 0
         self._disconnect_after = None
         self._executor = None
-        self._middlewareIterator = None
 
         signal.signal(signal.SIGTERM, self.handle_sigterm)
 
@@ -196,9 +195,8 @@ class Worker:
         self._server_middleware.append(middleware_function)
 
     def _call_server_middleware(self, job):
-        self._middlewareIterator = iter(self._server_middleware)
-        middlewareChain = next(self._middlewareIterator)
-        middlewareChain(self, job)
+        self._middleware_index = len(self._server_middleware)
+        self.chain_middleware(job)
 
     def chain_middleware(self, job):
         if self._middleware_index < len(self._server_middleware):
@@ -281,7 +279,6 @@ class Worker:
 
         except (KeyError, Exception) as e:
             self._fail(jid, exception=e)
-            self.log.info('job fails here')
 
     def _ack(self, jid: str):
         self.faktory.reply("ACK", {'jid': jid})

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -195,11 +195,11 @@ class Worker:
 
         #iterate through all middleware functions
         #call middleware functions for each key/pair value
-        for middleFunction, args in self._middleware.items():
+        for middleware_function, args in self._middleware.items():
             if args:
-                middleFunction(args)
+                middleware_function(args)
             else:
-                middleFunction()
+                middleware_function()
 
     def middleware(self, middleware_function, *args):
         #if the function is already registered within the middleware

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -269,6 +269,7 @@ class Worker:
     def _ack(self, jid: str):
         self.faktory.reply("ACK", {'jid': jid})
         ok = next(self.faktory.get_message())
+        self.log.info(ok)
 
     def _fail(self, jid: str, exception=None):
         response = {
@@ -280,6 +281,7 @@ class Worker:
 
         self.faktory.reply("FAIL", response)
         ok = next(self.faktory.get_message())
+        self.log.info(ok)
 
     def fail_all_jobs(self):
         for future in self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -204,7 +204,7 @@ class Worker:
                         self._middleware_values["func"] = middleware_return["func"]
                     if "args" in middleware_return:
                         self._middleware_values["args"] = middleware_return["args"]
-                elif middleware_return = "kill":
+                elif middleware_return == "kill":
                     self._cancel_job = True
 
     def client_middleware_reg(self, middleware_function, *args):

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -242,14 +242,16 @@ class Worker:
                     self._fail(future.job_id, exception=e)
                     self.log.exception("Task failed: {}".format(future.job_id))
 
-    def _process(self, job):
-
+    def process(self, job_load):
         jid = str(job.get('jid'))
         func = str(job.get('jobtype'))
         args = job.get('args')
+        self._process(jid, func, args)
+
+    def _process(self, jid: str, job: str, args):
 
         try:
-            task = self.get_registered_task(func)
+            task = self.get_registered_task(job)
             if task.bind:
                 # pass the jid as argument 1 if the task has bind=True
                 args = [jid, ] + args

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -198,12 +198,11 @@ class Worker:
 
             if middleware_return:
                 if type(middleware_return) is list:
-                    self._middleware_values[0] = middleware_return[0]
-                    self.middleware_value[1] = middleware_value[1]
-                    self.middleware_value[2] = middleware_value[2]
+                    for i in range(len(middleware_return)):
+                        self._middleware_values.append(middleware_return[i])
 
                 else:
-                    self.log.debug("{} returned unexpected type".format(middleware_function.__name__))
+                    self.log.debug("{} returned {}, expected list.".format(middleware_function.__name__, str(type(middleware_return))))
 
     def client_middleware_reg(self, middleware_function):
         self._client_middleware.append(middleware_function)

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -195,6 +195,8 @@ class Worker:
 
     def _call_server_middleware(self, job):
         middleware_iter = iter(self._server_middleware)
+        middleware_function = middleware_iter.__next__()
+        middleware_function(self, job, middleware_iter)
 
     def tick(self):
         if self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -247,7 +247,7 @@ class Worker:
                 self._pending.remove(future)
                 try:
                     future.result(timeout=1)
-                    self.(future.job_id)
+                    self._ack(future.job_id)
                 except BrokenProcessPool:
                     self._fail(future.job_id)
                 except KeyboardInterrupt:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -195,7 +195,6 @@ class Worker:
         self._server_middleware.append(middleware_function)
 
     def _call_server_middleware(self, job):
-        self._middleware_index = len(self._server_middleware)
         self.chain_middleware(job)
 
     def chain_middleware(self, job):

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -250,8 +250,8 @@ class Worker:
                     self.log.exception("Task failed: {}".format(future.job_id))
 
     def process(self, job):
-        jid = str(job.get('jid'))
-        func = str(job.get('jobtype'))
+        jid = job.get('jid')
+        func = job.get('jobtype')
         args = job.get('args')
         self._process(jid, func, args)
 
@@ -270,6 +270,7 @@ class Worker:
 
         except (KeyError, Exception) as e:
             self._fail(jid, exception=e)
+            self.log.info('job fails here')
 
     def _ack(self, jid: str):
         self.faktory.reply("ACK", {'jid': jid})

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -64,6 +64,7 @@ class Worker:
         self._tasks = dict()
         self._pending = list()
         self._server_middleware = list()
+        self._logging_middleware = list()
         self._disconnect_after = None
         self._executor = None
         self._middlewareIterator = None
@@ -205,6 +206,13 @@ class Worker:
         except StopIteration:
             self.process(job)
 
+    def logging_middleware_reg(self, middleware_function):
+        self._logging_middleware.append(middleware_function)
+
+    def _call_logging_middleware(self, jid, job_success, exception = None):
+        for middleware_function in self._logging_middleware:
+            middleware_function(jid, job_success, exception)
+
     def tick(self):
         if self._pending:
             self.send_status_to_faktory()
@@ -275,6 +283,8 @@ class Worker:
     def _ack(self, jid: str):
         self.faktory.reply("ACK", {'jid': jid})
         ok = next(self.faktory.get_message())
+        if self._logging_middleware:
+            self._call_logging_middleware(jid, True, None)
 
     def _fail(self, jid: str, exception=None):
         response = {
@@ -286,6 +296,8 @@ class Worker:
 
         self.faktory.reply("FAIL", response)
         ok = next(self.faktory.get_message())
+        if self._logging_middleware:
+            self._call_logging_middleware(jid, False, exception)
 
     def fail_all_jobs(self):
         for future in self._pending:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -195,15 +195,20 @@ class Worker:
 
     def _call_client_middleware(self, jid, func, args):
         for middleware_function, function_args in self._client_middleware.items():
+
             middleware_return = middleware_function(jid, func, args, *function_args)
+
             if middleware_return:
                 if type(middleware_return) is dict:
+
                     if "jid" in middleware_return:
                         self._middleware_values["jid"] = middleware_return["jid"]
                     if "func" in middleware_return:
                         self._middleware_values["func"] = middleware_return["func"]
                     if "args" in middleware_return:
+                        self.log.info(middleware_return[args])
                         self._middleware_values["args"] = middleware_return["args"]
+
                 elif middleware_return == "kill":
                     self._cancel_job = True
 
@@ -248,6 +253,7 @@ class Worker:
                             func = self._middleware_values["func"]
                         if "args" in self._middleware_values:
                             args = self._middleware_values["args"]
+                            self.log.info(args)
                         self._middleware_values.clear()
 
                 self._process(jid, func, args)

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -63,6 +63,7 @@ class Worker:
         self._last_heartbeat = None
         self._tasks = dict()
         self._pending = list()
+        self._logging_middleware = list()
         self._server_middleware = list()
         self._disconnect_after = None
         self._executor = None

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -201,7 +201,7 @@ class Worker:
     def chain_middleware(self, job):
         try:#yield
             middlewareChain = next(self._middlewareIterator)
-            middlewareChain(worker, job)
+            middlewareChain(self, job)
         except StopIteration:
             self.process(job)
 

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -206,7 +206,8 @@ class Worker:
                     if "func" in middleware_return:
                         self._middleware_values["func"] = middleware_return["func"]
                     if "args" in middleware_return:
-                        self._middleware_values["args"] = middleware_return["args"]
+                        self._middleware_values["args"] = tuple(middleware_return["args"])
+                        self.log(self._middleware_values["args"])
 
                 elif middleware_return == "kill":
                     self._cancel_job = True
@@ -254,6 +255,7 @@ class Worker:
                             args = self._middleware_values["args"]
                         self._middleware_values.clear()
 
+                self.log.info("{}: {}: {}".format(jid, func, args))
                 self._process(jid, func, args)
         else:
             if self.is_disconnecting:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -195,8 +195,6 @@ class Worker:
 
     def _call_server_middleware(self, job):
         middleware_iter = iter(self._server_middleware)
-        for middleware_function in self._server_middleware:
-            middleware_function(self, job, middleware_iter)
 
     def tick(self):
         if self._pending:
@@ -243,7 +241,7 @@ class Worker:
                     self.log.exception("Task failed: {}".format(future.job_id))
 
     def _process(self, job):
-        
+
         jid = str(job.get('jid'))
         func = str(job.get('jobtype'))
         args = job.get('args')

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -246,7 +246,7 @@ class Worker:
                         self.log.info("force failed job {}".format(jid))
                         return
 
-                    if self._middleware_values:
+                    elif self._middleware_values:
                         if "jid" in self._middleware_values:
                             jid = self._middleware_values["jid"]
                         if "func" in self._middleware_values:
@@ -293,7 +293,7 @@ class Worker:
                 # pass the jid as argument 1 if the task has bind=True
                 args = [jid, ] + args
 
-            self.log.debug("Running task: {}({})".format(task.name, ", ".join([str(x) for x in args])))
+            self.log.info("Running task: {}({})".format(task.name, ", ".join([str(x) for x in args])))
             future = self.executor.submit(task.func, *args)
             future.job_id = jid
             self._pending.append(future)

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -202,6 +202,10 @@ class Worker:
                 middleFunction()
 
     def middleware(self, middleware_function, *args):
+        #if the function is already registered within the middleware
+        #then ignore it to rewrite the assignment
+
+        #remove this line to overwrite functions
         if middleware_function not in self._middleware:
             self._middleware[middleware_function] = args
 

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -202,7 +202,7 @@ class Worker:
                 middleFunction()
 
     def middleware(self, middleware_function, *args):
-        if middleware_function not in self._middleware
+        if middleware_function not in self._middleware:
             self._middleware[middleware_function] = args
 
     def tick(self):

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -207,7 +207,6 @@ class Worker:
                         self._middleware_values["func"] = middleware_return["func"]
                     if "args" in middleware_return:
                         self._middleware_values["args"] = tuple(middleware_return["args"])
-                        self.log.info(self._middleware_values["args"])
 
                 elif middleware_return == "kill":
                     self._cancel_job = True
@@ -241,9 +240,9 @@ class Worker:
                     self._call_client_middleware(jid, func, args)
 
                     if self._cancel_job is True:
-                        self._cancel_job = False
                         self._fail(jid)
-                        self.log.info("force failed job {}".format(jid))
+                        self.log.debug("force failed job {}".format(jid))
+                        self._cancel_job = False
                         return
 
                     elif self._middleware_values:
@@ -255,7 +254,6 @@ class Worker:
                             args = self._middleware_values["args"]
                         self._middleware_values.clear()
 
-                self.log.info("{}: {}: {}".format(jid, func, args))
                 self._process(jid, func, args)
         else:
             if self.is_disconnecting:
@@ -293,7 +291,7 @@ class Worker:
                 # pass the jid as argument 1 if the task has bind=True
                 args = [jid, ] + args
 
-            self.log.info("Running task: {}({})".format(task.name, ", ".join([str(x) for x in args])))
+            self.log.debug("Running task: {}({})".format(task.name, ", ".join([str(x) for x in args])))
             future = self.executor.submit(task.func, *args)
             future.job_id = jid
             self._pending.append(future)

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -11,6 +11,7 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, Executor
 from concurrent.futures.process import BrokenProcessPool
 
 from collections import namedtuple
+from collections import OrderedDict
 
 from ._proto import Connection
 
@@ -63,8 +64,8 @@ class Worker:
         self._last_heartbeat = None
         self._tasks = dict()
         self._pending = list()
-        self._client_middleware = dict()
-        self._server_middleware = dict()
+        self._client_middleware = OrderedDict()
+        self._server_middleware = OrderedDict()
         self._disconnect_after = None
         self._executor = None
 
@@ -271,7 +272,7 @@ class Worker:
         self.faktory.reply("ACK", {'jid': jid})
         ok = next(self.faktory.get_message())
         if self._server_middleware:
-            self._call_server_middleware(jid, "finished", None)
+            self._call_server_middleware(jid, True, None)
 
     def _fail(self, jid: str, exception=None):
         response = {
@@ -284,7 +285,7 @@ class Worker:
         self.faktory.reply("FAIL", response)
         ok = next(self.faktory.get_message())
         if self._server_middleware:
-            self._call_server_middleware(jid, "failed", exception)
+            self._call_server_middleware(jid, False, exception)
 
     def fail_all_jobs(self):
         for future in self._pending:


### PR DESCRIPTION
The company I'm interning with needed middleware functionality similar to that found in the faktory ruby worker but for the python jobs their applications runs, and needed it to be simple enough to not cause any ripples through the preexisting codebase. This is a simple addition that I coded for them that allows all middleware to be created and managed from worker.py. Hopefully this is helpful, but any feedback would also be greatly appreciated.