### PR TITLE
Allow work tasks that last more than 15s

### DIFF
--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -128,8 +128,6 @@ class Connection:
                             yield resp
                         elif chr(line[0]) == '-':
                             resp = line[1:].decode().strip("\r\n ")
-                            if self.debug: self.log.debug("> {}".format(resp))
-                            yield resp
                         elif chr(line[0]) == '$':
                             # read $xxx bytes of data into a buffer
                             number_of_bytes = int(line[1:]) + 2  # add 2 bytes so we read the \r\n from the end

--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -157,7 +157,7 @@ class Connection:
                         else:
                             buffer += more
         for msg in inner():
-            logging.info("get_message result %s", msg)
+            logging.info("get_message result {}", msg)
             yield msg
 
     def fetch(self, queues) -> Optional[dict]:
@@ -165,7 +165,7 @@ class Connection:
         job = next(self.get_message())
         if not job:
             return None
-        logging.info('Job Fetch Result: %s (%d chars)', job, len(job))
+        logging.info('Job Fetch Result: {} ({} chars)', job, len(job))
 
         data = json.loads(job)
         return data
@@ -178,7 +178,7 @@ class Connection:
                 s = "{} {}".format(s, json.dumps(data))
             else:
                 s = "{} {}".format(s, data)
-        logging.info('Sent raw server message: %s (%d chars)', s, len(s))
+        logging.info('Sent raw server message: {} ({} chars)', s, len(s))
         self.socket.send(str.encode(s + "\r\n"))
 
     def disconnect(self):

--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -71,7 +71,7 @@ class Connection:
             raise FaktoryHandshakeError("Could not connect to Faktory; expected HI from server, but got '{}'".format(ahoy))
 
         response = {
-            'hostname': str(uuid.uuid4()),
+            'hostname': socket.gethostname(),
             'pid': os.getpid(),
             "labels": self.labels
         }

--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -157,7 +157,7 @@ class Connection:
                         else:
                             buffer += more
         for msg in inner():
-            logging.info("get_message result {}", msg)
+            logging.info("get_message result %s", msg)
             yield msg
 
     def fetch(self, queues) -> Optional[dict]:
@@ -165,7 +165,7 @@ class Connection:
         job = next(self.get_message())
         if not job:
             return None
-        logging.info('Job Fetch Result: {} ({} chars)', job, len(job))
+        logging.info('Job Fetch Result: %s (%d chars)', job, len(job))
 
         data = json.loads(job)
         return data
@@ -178,7 +178,7 @@ class Connection:
                 s = "{} {}".format(s, json.dumps(data))
             else:
                 s = "{} {}".format(s, data)
-        logging.info('Sent raw server message: {} ({} chars)', s, len(s))
+        logging.info('Sent raw server message: %s (%d chars)', s, len(s))
         self.socket.send(str.encode(s + "\r\n"))
 
     def disconnect(self):

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -20,7 +20,7 @@ Task = namedtuple('Task', ['name', 'func', 'bind'])
 
 
 class Worker:
-    send_heartbeat_every = 15  # seconds
+    send_heartbeat_every = 13  # seconds
     is_quiet = False
     is_disconnecting = False
 

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -128,8 +128,7 @@ class Worker:
             while True:
                 try:
                     await asyncio.sleep(self.send_heartbeat_every)
-                    if self.should_send_heartbeat:
-                        self.heartbeat()
+                    self.heartbeat()
                 except Exception:
                     sys.exit()  # basically, worker has crashed and its status has been comprimised.
                     # exit the heartbeat thread associated with this worker
@@ -308,20 +307,6 @@ class Worker:
     @property
     def can_disconnect(self):
         return len(self._pending) == 0
-
-    @property
-    def should_send_heartbeat(self) -> bool:
-        """
-        Checks `self._last_heartbeat` and `self.send_heartbeat_every` to figure out of this worker needs to send a
-        heartbeat to the Faktory server. The beat should be sent once per 60s max, and defaults to once per 15s.
-
-        Chances are you don't want to override this in a subclass, but change the property `self.send_heartbeat_every`
-        instead.
-
-        :return: True if this worker should heartbeat
-        :rtype: bool
-        """
-        return datetime.now() > (self._last_heartbeat + timedelta(seconds=self.send_heartbeat_every))
 
     def heartbeat(self):
         """


### PR DESCRIPTION
G'day, we've got a bunch of long-running batch jobs that we've been using faktory for - unfortunately they became out of sync with the server because it kept missing its heartbeat interval (as the jobs were talking more than 15s).

This changes the heartbeat mechanism to instead use a separate thread in order to prevent being blocked by the work currently being done by the worker