### PR TITLE
raise FaktoryConnectionResetError when connection is severed

### DIFF
--- a/faktory/exceptions.py
+++ b/faktory/exceptions.py
@@ -7,3 +7,7 @@ class FaktoryHandshakeError(ConnectionError):
 
 class FaktoryAuthenticationError(ConnectionError):
     pass
+
+
+class FaktoryConnectionResetError(ConnectionResetError):
+    pass


### PR DESCRIPTION
This code change raises a FaktoryConnectionResetError if the connection to the faktory server is severed. I was having an issue where the socket.recv would hang indefinitely and not exit the process when the connection to the server is closed.