### PR TITLE
change exception inheritance for use of catch all faktory error

### DIFF
--- a/faktory/exceptions.py
+++ b/faktory/exceptions.py
@@ -22,5 +22,5 @@ class FaktoryAuthenticationError(FaktoryError, ConnectionError):
     pass
 
 
-class FaktoryConnectionResetError(FaktoryError, ConnectionError):
+class FaktoryConnectionResetError(FaktoryError, ConnectionResetError):
     pass

--- a/faktory/exceptions.py
+++ b/faktory/exceptions.py
@@ -1,13 +1,26 @@
-__ALL__ = ['FaktoryHandshakeError', 'FaktoryAuthenticationError']
+__ALL__ = ["FaktoryHandshakeError", "FaktoryAuthenticationError", "FaktoryError"]
 
 
-class FaktoryHandshakeError(ConnectionError):
+class FaktoryError(Exception):
+    """
+    The base Faktory Exception that all other Faktory related
+    exceptions inherit from. To catch any other, more specific,
+    Faktory exception, catch this one and handle appropriately.
+
+    This Exception should not be used, and is in place strictly
+    as a way to catch all `Faktory` exceptions.
+    """
+
     pass
 
 
-class FaktoryAuthenticationError(ConnectionError):
+class FaktoryHandshakeError(FaktoryError, ConnectionError):
     pass
 
 
-class FaktoryConnectionResetError(ConnectionResetError):
+class FaktoryAuthenticationError(FaktoryError, ConnectionError):
+    pass
+
+
+class FaktoryConnectionResetError(FaktoryError, ConnectionError):
     pass

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,39 @@
+import pytest
+
+from faktory.exceptions import (
+    FaktoryAuthenticationError,
+    FaktoryConnectionResetError,
+    FaktoryError,
+    FaktoryHandshakeError,
+)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [FaktoryAuthenticationError, FaktoryConnectionResetError, FaktoryHandshakeError],
+)
+def test_errors_are_caught_with_connection_errors(exc: Exception):
+    """
+    Tests to make sure that handling a `ConnectionError` will allow
+    us to also catch the custom, more description exceptions we
+    have implemented.
+    """
+
+    with pytest.raises(ConnectionError):
+        raise exc
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [FaktoryAuthenticationError, FaktoryConnectionResetError, FaktoryHandshakeError],
+)
+def test_inherits_from_base_project_exception(exc: Exception):
+    """
+    Tests to make sure that all custom exceptions that we have
+    defined are inheriting from our base `FaktoryError` class,
+    so that when someone handles a `FaktoryError`, any of the
+    subclasses will be caught appropriately.
+    """
+
+    with pytest.raises(FaktoryError):
+        raise exc


### PR DESCRIPTION
This PR should allow for a "top level" exception that can be caught for all Faktory specific errors.

This PR changed the inheritance of the existing exceptions to inherit from the "base" Faktory exception, as well as the existing `ConnectionError` for backwards compatibility.