### PR TITLE
Ensure all data is sent and raise an error when connection is reset

### DIFF
--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -320,7 +320,12 @@ class Connection:
                 s = "{} {}".format(s, json.dumps(data))
             else:
                 s = "{} {}".format(s, data)
-        self.socket.send(str.encode(s + "\r\n"))
+        buffer = str.encode(s + "\r\n")
+        while len(buffer):
+            sent = self.socket.send(buffer)
+            if sent == 0:
+                raise FaktoryConnectionResetError
+            buffer = buffer[sent:]
 
     def disconnect(self):
         self.log.info("Disconnected")


### PR DESCRIPTION
This addresses similar issues outlined in #20 and #10 with regard to sending data.

* A return value of zero after calling `send` indicates the socket connection died and we should raise an error.
* `socket.send` does not guarantee all bytes will be sent in a single call, so we continue sending chunks until all is sent.
