### PR TITLE
Recover from broken process pool

### DIFF
--- a/faktory/client.py
+++ b/faktory/client.py
@@ -7,8 +7,8 @@ from ._proto import Connection
 class Client:
     is_connected = False
 
-    def __init__(self, faktory=None, connection=None):
-        self.faktory = connection or Connection(faktory)
+    def __init__(self, faktory=None, connection=None, **kwargs):
+        self.faktory = connection or Connection(faktory, **kwargs)
 
     def __enter__(self):
         self.connect()

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -4,7 +4,7 @@ import sys
 import time
 import uuid
 from collections import namedtuple
-from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor, BrokenExecutor
 from concurrent.futures.process import BrokenProcessPool
 from concurrent.futures.thread import BrokenThreadPool
 from datetime import datetime, timedelta
@@ -273,7 +273,7 @@ class Worker:
             future.job_id = jid
             self._pending.append(future)
         except BrokenExecutor as e:
-            logging.info("Handling broken executor")
+            logging.info("Handling broken executor -- ")
             self._executor = None
             self._fail(jid, exception=e)
         except (KeyError, Exception) as e:

--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -252,7 +252,6 @@ class Worker:
                     self.log.exception("Received KeyboardInterrupt! failed: {}".format(future.job_id))
                 except Exception as e:
                     self._fail(future.job_id, exception=e)
-                    self.log.info("future.result returned exception")
                     self.log.exception("Task failed: {}".format(future.job_id))
 
     def _process(self, jid: str, job: str, args):
@@ -273,7 +272,6 @@ class Worker:
             future.job_id = jid
             self._pending.append(future)
         except BrokenExecutor as e:
-            logging.info("Handling broken executor -- ")
             self._executor = None
             self._fail(jid, exception=e)
         except (KeyError, Exception) as e:


### PR DESCRIPTION
We hit a pretty unfortunate edge case in this library where one broken process will corrupt the entire pool.  When that happens, the entire process pool (`self._executor`) is broken and the worker does not recover, but it also does not terminate.  The result is that it continues to pick up new jobs and send them to the process pool to execute and they immediately throw a BrokenExecutor exception. For us, this resulted in the corrupt worker essentially draining our queue and funneling them directly to the dead queue. 

It does look like there is an older attempt to handle this [here](https://github.com/cdrx/faktory_worker_python/blob/master/faktory/worker.py#L177), however it is unreachable because [this line](https://github.com/cdrx/faktory_worker_python/blob/master/faktory/worker.py#L252) catches all exceptions first.  

The fix in this pr, which we've been using for a while now, recovers from this state by throwing the broken process pool away and letting the next tick re-create a fresh one.  This has been working really well, since broken processes are very rare (for us), and all the initial jobs impacted by the broken process are retried.  

This PR also includes a small useful change to enable the proto client to accept and pass all the kwargs that the connection accepts along. We use that client directly in a few places and need to forward some options to the connection. 
