### PR TITLE
Prefix thread names

### DIFF
--- a/faktory/worker.py
+++ b/faktory/worker.py
@@ -370,7 +370,10 @@ class Worker:
         :rtype: concurrent.futures.Executor
         """
         if self._executor is None:
-            self._executor = self._executor_class(max_workers=self.concurrency)
+            kwargs = dict(max_workers=self.concurrency)
+            if self._executor_class is ThreadPoolExecutor:
+                kwargs['thread_name_prefix'] = 'Worker'
+            self._executor = self._executor_class(**kwargs)
         return self._executor
 
     def get_queues(self) -> Iterable:


### PR DESCRIPTION
Thread names appear in logs. The default naming scheme is something like `ThreadPoolExecutor_x_y`, with `x` enumerating `ThreadPoolExecutor` and `y` enumerating threads. This changes the thread name into something more recognizable, especially in environments where other named threads are operating. `Worker_0`, `Worker_1`, etc.

`Faktory` could also be an alternative naming. The standard seems to be camel case names for threads.