### PR TITLE
Fix apparent connection resets due to SSL socket errors

### DIFF
--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -271,16 +271,10 @@ class Connection:
                                 self.log.debug("> {}".format("nil"))
                             yield ""
                         else:
-                            if len(buffer) >= number_of_bytes:
-                                # we've already got enough bytes in the buffer
-                                data = buffer[:number_of_bytes]
-                                buffer = buffer[number_of_bytes:]
-                            else:
-                                data = buffer
-                                while len(data) != number_of_bytes:
-                                    bytes_required = number_of_bytes - len(data)
-                                    data += self.select_data(bytes_required)
-                                buffer = []
+                            while len(buffer) < number_of_bytes:
+                                buffer += self.select_data()
+                            data = buffer[:number_of_bytes]
+                            buffer = buffer[number_of_bytes:]
                             resp = data.decode().strip("\r\n ")
                             if self.debug:
                                 self.log.debug("> {}".format(resp))

--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -243,7 +243,7 @@ class Connection:
 
     def get_message(self) -> Iterator[str]:
         socket = self.socket
-        buffer = self.select_data(self.buffer_size)
+        buffer = self.select_data()
         while self.is_connected or self.is_connecting:
             buffering = True
             while buffering:
@@ -286,17 +286,17 @@ class Connection:
                                 self.log.debug("> {}".format(resp))
                             yield resp
                 else:
-                    more = self.select_data(self.buffer_size)
+                    more = self.select_data()
                     if not more:
                         buffering = False
                     else:
                         buffer += more
 
-    def select_data(self, buffer_size: int):
+    def select_data(self):
         s = self.socket
         ready = select.select([s], [], [], self.timeout)
         if ready[0]:
-            buffer = s.recv(buffer_size)
+            buffer = s.recv(self.buffer_size)
             if len(buffer) > 0:
                 return buffer
         self.disconnect()

--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -297,6 +297,10 @@ class Connection:
         ready = select.select([s], [], [], self.timeout)
         if ready[0]:
             buffer = s.recv(self.buffer_size)
+            unread = s.pending()
+            while unread:
+                buffer += s.recv(unread)
+                unread = s.pending()
             if len(buffer) > 0:
                 return buffer
         self.disconnect()

--- a/faktory/_proto.py
+++ b/faktory/_proto.py
@@ -291,10 +291,11 @@ class Connection:
         ready = select.select([s], [], [], self.timeout)
         if ready[0]:
             buffer = s.recv(self.buffer_size)
-            unread = s.pending()
-            while unread:
-                buffer += s.recv(unread)
+            if self.use_tls:
                 unread = s.pending()
+                while unread:
+                    buffer += s.recv(unread)
+                    unread = s.pending()
             if len(buffer) > 0:
                 return buffer
         self.disconnect()


### PR DESCRIPTION
I kept running into connection resets when enabling TLS. The issue is explained here:

https://stackoverflow.com/questions/3187565/select-and-ssl-in-python

> Another problem is, if you write 2048 bytes to the connection at the other end, the select() on your end returns. But if you then only read 1024 bytes from the SSL socket, it is possible that the SSL socket internally reads more data, and the next select() won't return even though there would be more data to read, possibly deadlocking the connection. This is because the raw socket, which is what select() is using, doesn't have any data since it's already in the SSL socket's buffers.
